### PR TITLE
Remove byte order mark

### DIFF
--- a/content/02.body.md
+++ b/content/02.body.md
@@ -1,4 +1,4 @@
-﻿## 1. CPLS parameters
+## 1. CPLS parameters
 
 The Ti:Sapph CETAL-PW Laser System (CPLS) has a wavelength $\lambda_L = 800$ nanometers. The focal length of its off-axis parabolic mirror (OAP) is 3.2 meters, while the beam size is 200 millimeters. We can take the pulse duration to be $\tau_L = 40$ fs at FWHM in intensity. 
 


### PR DESCRIPTION
Attempting to fix the first section header reported in https://github.com/manubot/rootstock/issues/247

Uses the `sed` command from https://unix.stackexchange.com/questions/381230/how-can-i-remove-the-bom-from-a-utf-8-file

My local diff show:
```
$ git diff
diff --git a/content/02.body.md b/content/02.body.md
index 4a5663c..0babb8a 100644
--- a/content/02.body.md
+++ b/content/02.body.md
@@ -1,4 +1,4 @@
-<U+FEFF>## 1. CPLS parameters
+## 1. CPLS parameters
 ```